### PR TITLE
Implement quote/delim encode settings

### DIFF
--- a/src/Csv/Encode.elm
+++ b/src/Csv/Encode.elm
@@ -42,13 +42,13 @@ type alias Csv =
     }
 
 
-type alias EncodeSettings =
+type alias Settings =
     { quoted : Bool
     , delimiter : String
     }
 
 
-defaultEncodeSettings : EncodeSettings
+defaultEncodeSettings : Settings
 defaultEncodeSettings =
     { quoted = True, delimiter = "," }
 
@@ -60,9 +60,9 @@ toEncoder =
     toEncoderWith defaultEncodeSettings
 
 
-{-| A bytes encoder for `Csv`s with `EncodeSettings`.
+{-| A bytes encoder for `Csv`s with `Settings`.
 -}
-toEncoderWith : EncodeSettings -> Csv -> E.Encoder
+toEncoderWith : Settings -> Csv -> E.Encoder
 toEncoderWith setts { headers, records } =
     E.sequence
         [ formatLines setts (headers :: records)
@@ -77,9 +77,9 @@ toBytes =
     toBytesWith defaultEncodeSettings
 
 
-{-| Convert a `Csv` to bytes with `EncodeSettings`.
+{-| Convert a `Csv` to bytes with `Settings`.
 -}
-toBytesWith : EncodeSettings -> Csv -> Bytes
+toBytesWith : Settings -> Csv -> Bytes
 toBytesWith setts =
     toEncoderWith setts >> E.encode
 
@@ -91,9 +91,9 @@ toString =
     toStringWith defaultEncodeSettings
 
 
-{-| Convert a `Csv` to a string with `EncodeSettings`.
+{-| Convert a `Csv` to a string with `Settings`.
 -}
-toStringWith : EncodeSettings -> Csv -> String
+toStringWith : Settings -> Csv -> String
 toStringWith setts csv =
     let
         bytes =
@@ -110,7 +110,7 @@ toStringWith setts csv =
             toString csv
 
 
-formatLines : EncodeSettings -> List (List String) -> E.Encoder
+formatLines : Settings -> List (List String) -> E.Encoder
 formatLines setts =
     List.map (formatRow setts)
         >> List.intersperse crlf
@@ -132,7 +132,7 @@ crlf =
     E.string "\u{000D}\n"
 
 
-formatRow : EncodeSettings -> List String -> E.Encoder
+formatRow : Settings -> List String -> E.Encoder
 formatRow ({ delimiter } as setts) =
     List.map (formatField setts)
         >> List.intersperse delimiter
@@ -140,7 +140,7 @@ formatRow ({ delimiter } as setts) =
         >> E.sequence
 
 
-formatField : EncodeSettings -> String -> String
+formatField : Settings -> String -> String
 formatField { quoted, delimiter } s =
     if quoted || String.contains delimiter s then
         "\"" ++ escapeString s ++ "\""

--- a/src/Csv/Encode.elm
+++ b/src/Csv/Encode.elm
@@ -42,9 +42,9 @@ type alias Csv =
     }
 
 
-{-| This type is for encode settings. `delimiter` is the CSV delimiter
-and can be more than one charcater. If `alwaysQuoted` is `False` only
-those values are quoted that contain a quote character (`"`).
+{-| This type is for encode settings. `delimiter` is the CSV
+delimiter. If `alwaysQuoted` is `False` only those values are quoted
+that contain a quote character (`"`).
 -}
 type alias Settings =
     { alwaysQuoted : Bool

--- a/src/Csv/Encode.elm
+++ b/src/Csv/Encode.elm
@@ -1,14 +1,15 @@
-module Csv.Encode exposing (Csv, toString, toBytes, toEncoder)
+module Csv.Encode exposing
+    ( Csv, toString, toBytes, toEncoder
+    , toBytesWith, toEncoderWith, toStringWith
+    )
 
 {-| This module provides support for rendering data in csv (comma separateed
 values) format. The format emitted is as described in [RFC4180][1].
-
 If you want to _parse_ csv files, look at the package `periodic/elm-csv`;
 this package is designed to work well with it.
 
 @docs Csv, toString, toBytes, toEncoder
-
-[1]: https://tools.ietf.org/html/rfc4180
+@docs [1]: https://tools.ietf.org/html/rfc4180
 
 -}
 
@@ -41,12 +42,30 @@ type alias Csv =
     }
 
 
-{-| A bytes encoder for `Csv`s
+type alias EncodeSettings =
+    { quoted : Bool
+    , delimiter : String
+    }
+
+
+defaultEncodeSettings : EncodeSettings
+defaultEncodeSettings =
+    { quoted = True, delimiter = "," }
+
+
+{-| A bytes encoder for `Csv`s.
 -}
 toEncoder : Csv -> E.Encoder
-toEncoder { headers, records } =
+toEncoder =
+    toEncoderWith defaultEncodeSettings
+
+
+{-| A bytes encoder for `Csv`s with `EncodeSettings`.
+-}
+toEncoderWith : EncodeSettings -> Csv -> E.Encoder
+toEncoderWith setts { headers, records } =
     E.sequence
-        [ formatLines (headers :: records)
+        [ formatLines setts (headers :: records)
         , crlf
         ]
 
@@ -55,16 +74,30 @@ toEncoder { headers, records } =
 -}
 toBytes : Csv -> Bytes
 toBytes =
-    toEncoder >> E.encode
+    toBytesWith defaultEncodeSettings
+
+
+{-| Convert a `Csv` to bytes with `EncodeSettings`.
+-}
+toBytesWith : EncodeSettings -> Csv -> Bytes
+toBytesWith setts =
+    toEncoderWith setts >> E.encode
 
 
 {-| Convert a `Csv` to a string.
 -}
 toString : Csv -> String
-toString csv =
+toString =
+    toStringWith defaultEncodeSettings
+
+
+{-| Convert a `Csv` to a string with `EncodeSettings`.
+-}
+toStringWith : EncodeSettings -> Csv -> String
+toStringWith setts csv =
     let
         bytes =
-            toBytes csv
+            toBytesWith setts csv
     in
     case D.decode (D.string (Bytes.width bytes)) bytes of
         Just v ->
@@ -77,44 +110,43 @@ toString csv =
             toString csv
 
 
-formatLines : List (List String) -> E.Encoder
-formatLines =
-    List.map formatRow
+formatLines : EncodeSettings -> List (List String) -> E.Encoder
+formatLines setts =
+    List.map (formatRow setts)
         >> List.intersperse crlf
         >> E.sequence
 
 
 {-| Encode the string `"\r\n"`.
-
 This is used as a line separator in the csv format (as well as other protocols
 and file formats like HTTP, windows text files, ...).
-
 `elm-format` insists on replacing the `"\r"` escape sequence with `"\u{000D}"`,
 which is comparatively unreadable. A constant seemed like an easier solution
 than fighting with a tool.
-
 I(isd) submitted a patch to change the behavior, but the maintainer doesn't seem
 to be terribly interested in merging it:
-
 <https://github.com/avh4/elm-format/pull/515>
-
 -}
 crlf : E.Encoder
 crlf =
     E.string "\u{000D}\n"
 
 
-formatRow : List String -> E.Encoder
-formatRow =
-    List.map formatField
-        >> List.intersperse ","
+formatRow : EncodeSettings -> List String -> E.Encoder
+formatRow ({ delimiter } as setts) =
+    List.map (formatField setts)
+        >> List.intersperse delimiter
         >> List.map E.string
         >> E.sequence
 
 
-formatField : String -> String
-formatField s =
-    "\"" ++ escapeString s ++ "\""
+formatField : EncodeSettings -> String -> String
+formatField { quoted, delimiter } s =
+    if quoted || String.contains delimiter s then
+        "\"" ++ escapeString s ++ "\""
+
+    else
+        escapeString s
 
 
 {-| Escape double quotes in a string.

--- a/src/Csv/Encode.elm
+++ b/src/Csv/Encode.elm
@@ -42,15 +42,19 @@ type alias Csv =
     }
 
 
+{-| This type is for encode settings. `delimiter` is the CSV delimiter
+and can be more than one charcater. If `alwaysQuoted` is `False` only
+those values are quoted that contain a quote character (`"`).
+-}
 type alias Settings =
-    { quoted : Bool
+    { alwaysQuoted : Bool
     , delimiter : String
     }
 
 
 defaultSettings : Settings
 defaultSettings =
-    { quoted = True, delimiter = "," }
+    { alwaysQuoted = True, delimiter = "," }
 
 
 {-| A bytes encoder for `Csv`s.
@@ -141,8 +145,8 @@ formatRow ({ delimiter } as setts) =
 
 
 formatField : Settings -> String -> String
-formatField { quoted, delimiter } s =
-    if quoted || String.contains delimiter s then
+formatField { alwaysQuoted, delimiter } s =
+    if alwaysQuoted || String.contains delimiter s then
         "\"" ++ escapeString s ++ "\""
 
     else

--- a/src/Csv/Encode.elm
+++ b/src/Csv/Encode.elm
@@ -48,8 +48,8 @@ type alias Settings =
     }
 
 
-defaultEncodeSettings : Settings
-defaultEncodeSettings =
+defaultSettings : Settings
+defaultSettings =
     { quoted = True, delimiter = "," }
 
 
@@ -57,7 +57,7 @@ defaultEncodeSettings =
 -}
 toEncoder : Csv -> E.Encoder
 toEncoder =
-    toEncoderWith defaultEncodeSettings
+    toEncoderWith defaultSettings
 
 
 {-| A bytes encoder for `Csv`s with `Settings`.
@@ -74,7 +74,7 @@ toEncoderWith setts { headers, records } =
 -}
 toBytes : Csv -> Bytes
 toBytes =
-    toBytesWith defaultEncodeSettings
+    toBytesWith defaultSettings
 
 
 {-| Convert a `Csv` to bytes with `Settings`.
@@ -88,7 +88,7 @@ toBytesWith setts =
 -}
 toString : Csv -> String
 toString =
-    toStringWith defaultEncodeSettings
+    toStringWith defaultSettings
 
 
 {-| Convert a `Csv` to a string with `Settings`.


### PR DESCRIPTION
Hi, I recently needed support for some encoding settings. Are you interested to merge and publish my changes?

Basically, `quote` tells if *all* cells should be quoted and `delimiter` changes the delimiter.

If the delimiter appears in a cell value, the cell value is quoted regardless of the `quote` setting.

Many of the visible diffs are whitespace changes after elm reformatted the code.